### PR TITLE
Compile fewer methods

### DIFF
--- a/src/integrators.jl
+++ b/src/integrators.jl
@@ -1,4 +1,5 @@
 import DataStructures
+import Base.Cartesian: @nexprs
 
 """
     DistributedODEIntegrator <: AbstractODEIntegrator
@@ -226,14 +227,13 @@ reached_tstop(integrator, tstop, stop_at_tstop = integrator.dtchangeable) =
     integrator.t == tstop || (!stop_at_tstop && is_past_t(integrator, tstop))
 
 
-@inline unrolled_foreach(::Tuple{}, integrator) = nothing
-@inline unrolled_foreach(callback, integrator) =
-    callback.condition(integrator.u, integrator.t, integrator) ? callback.affect!(integrator) : nothing
-@inline unrolled_foreach(discrete_callbacks::Tuple{Any}, integrator) =
-    unrolled_foreach(first(discrete_callbacks), integrator)
-@inline function unrolled_foreach(discrete_callbacks::Tuple, integrator)
-    unrolled_foreach(first(discrete_callbacks), integrator)
-    unrolled_foreach(Base.tail(discrete_callbacks), integrator)
+@generated function unrolled_foreach(::Val{N}, callbacks, integrator) where {N}
+    return quote
+        @nexprs $N i -> begin
+            callback = callbacks[i]
+            callback.condition(integrator.u, integrator.t, integrator) ? callback.affect!(integrator) : nothing
+        end
+    end
 end
 
 function __step!(integrator)
@@ -257,7 +257,7 @@ function __step!(integrator)
 
     # apply callbacks
     discrete_callbacks = integrator.callback.discrete_callbacks
-    unrolled_foreach(discrete_callbacks, integrator)
+    unrolled_foreach(Val(length(discrete_callbacks)), discrete_callbacks, integrator)
 
     # remove tstops that were just reached
     while !isempty(tstops) && reached_tstop(integrator, first(tstops))


### PR DESCRIPTION
Inspired by , this PR attempts to reduce the number of compile methods (and hopefully overall compilation time) by using Base.Cartesian utilities:

```julia
using Revise; include("perf/jet.jl")
using MethodAnalysis
import ClimaTimeSteppers as CTS
length(methodinstances(CTS.update_stage!))
length(methodinstances(CTS.unrolled_foreach))
```


#### Main

```julia
julia> using Revise; include("perf/jet.jl")
Precompiling ClimaTimeSteppers
  1 dependency successfully precompiled in 3 seconds. 180 already precompiled.
step_allocs = 12768
Test Summary:     | Pass  Total  Time
JET / allocations |    2      2  3.1s
Test.DefaultTestSet("JET / allocations", ^R
^[[Any[], 2, false, false, true, 1.728926011863406e9, 1.728926014999377e9, false, "/Users/charliekawczynski/Dropbox/Caltech/work/dev/CliMA/ClimaTimeSteppers.jl/perf/jet.jl")

julia> using MethodAnalysis

julia> import ClimaTimeSteppers as CTS

julia> length(methodinstances(CTS.update_stage!))
5

julia> length(methodinstances(CTS.unrolled_foreach))
10
```

#### This branch

```julia
julia> using Revise; include("perf/jet.jl")
Precompiling ClimaTimeSteppers
  1 dependency successfully precompiled in 5 seconds. 180 already precompiled.
step_allocs = 12768
Test Summary:     | Pass  Total  Time
JET / allocations |    2      2  3.7s
Test.DefaultTestSet("JET / allocations", Any[], 2, false, false, true, 1.728925925530902e9, 1.728925929182172e9, false, "/Users/charliekawczynski/Dropbox/Caltech/work/dev/CliMA/ClimaTimeSteppers.jl/perf/jet.jl")
julia> using MethodAnalysis

julia> import ClimaTimeSteppers as CTS

julia> length(methodinstances(CTS.update_stage!))
2

julia> length(methodinstances(CTS.unrolled_foreach))
1
```

I think I'd better use SnoopCompile to incorporate the importance of timings in real-world cases.