### PR TITLE
Move allocs test to end of flame script

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -32,12 +32,6 @@ prof = Profile.@profile begin
     do_work!(integrator, cache)
 end
 
-p = @allocated do_work!(integrator, cache)
-using Test
-@testset "Allocations" begin
-    @test p == 0
-end
-
 import ProfileCanvas
 
 if haskey(ENV, "BUILDKITE_COMMIT") || haskey(ENV, "BUILDKITE_BRANCH")
@@ -46,4 +40,10 @@ if haskey(ENV, "BUILDKITE_COMMIT") || haskey(ENV, "BUILDKITE_BRANCH")
     ProfileCanvas.html_file(joinpath(output_dir, "flame.html"))
 else
     ProfileCanvas.view(Profile.fetch())
+end
+
+p = @allocated do_work!(integrator, cache)
+using Test
+@testset "Allocations" begin
+    @test p == 0
 end


### PR DESCRIPTION
So that the flame graph is always exported (in case allocations fail).