### PR TITLE
Fix callback issue in SciMLBase.solve

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.10"
+version = "0.8.11"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/ext/ClimaTimeSteppersSciMLExt.jl
+++ b/ext/ClimaTimeSteppersSciMLExt.jl
@@ -87,19 +87,23 @@ function SciMLBase.solve(
     prob::SciMLBase.AbstractODEProblem,
     alg::CTS.DistributedODEAlgorithm,
     args...;
+    callback = nothing,
     kwargs...,
 )
     local_prob = CTS.ODEProblem(convert_f(prob.f), prob.u0, prob.tspan, prob.p)
-    CTS.solve(local_prob, alg, args...; kwargs...)
+    callback = convert_cb(callback)
+    CTS.solve(local_prob, alg, args...; callback, kwargs...)
 end
 
 function SciMLBase.solve(
     prob::CTS.ODEProblem,
     alg::CTS.DistributedODEAlgorithm,
     args...;
+    callback = nothing,
     kwargs...,
 )
-    CTS.solve(prob, alg, args...; kwargs...)
+    callback = convert_cb(callback)
+    CTS.solve(prob, alg, args...; callback, kwargs...)
 end
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In `solve`, the callback is now converted from a `SciMLBase.CallbackSet` to a `CTS.CallbackSet`.

This PR is needed to fix ClimaLand CI. See https://github.com/CliMA/ClimaLand.jl/pull/1682