### PR TITLE
update ClimaCoupler env in downstream tests

### DIFF
--- a/.buildkite/downstream/climacoupler.jl
+++ b/.buildkite/downstream/climacoupler.jl
@@ -18,5 +18,5 @@ push!(ARGS,
     joinpath(coupler_dir, "config", "ci_configs", "slabplanet_default.yml"),
     "--job_id", "cts_downstream_test",
 )
-include(joinpath(coupler_dir, "experiments", "ClimaEarth", "run_amip.jl"))
+include(joinpath(coupler_dir, "experiments", "AMIP", "run_simulation.jl"))
 @info "ClimaCoupler: completed successfully"

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -70,32 +70,31 @@ jobs:
           julia --color=yes --project=climaland/.buildkite -e 'using Pkg; Pkg.precompile()'
           julia --color=yes --project=climaland/.buildkite .buildkite/downstream/climaland.jl
 
-  # Disabled until ClimaCoupler updates compat bounds for ClimaLand ≥ 1.6.3
-  # climacoupler:
-  #   name: ClimaCoupler.jl
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: true
-  #   timeout-minutes: 60
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       version:
-  #         - '1.11'
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: julia-actions/setup-julia@v2
-  #       with:
-  #         version: ${{ matrix.version }}
-  #     - uses: julia-actions/cache@v3
-  #     - uses: julia-actions/julia-buildpkg@v1
-  #     - uses: actions/checkout@v6
-  #       with:
-  #         repository: 'CliMA/ClimaCoupler.jl'
-  #         path: climacoupler
-  #     - env:
-  #         CLIMACOUPLER_DIR: climacoupler
-  #       run: |
-  #         julia --color=yes --project=climacoupler/experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate()'
-  #         julia --color=yes --project=climacoupler/experiments/ClimaEarth -e 'using Pkg; Pkg.develop(path=".")'
-  #         julia --color=yes --project=climacoupler/experiments/ClimaEarth -e 'using Pkg; Pkg.precompile()'
-  #         julia --color=yes --project=climacoupler/experiments/ClimaEarth .buildkite/downstream/climacoupler.jl
+  climacoupler:
+    name: ClimaCoupler.jl
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.11'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: actions/checkout@v6
+        with:
+          repository: 'CliMA/ClimaCoupler.jl'
+          path: climacoupler
+      - env:
+          CLIMACOUPLER_DIR: climacoupler
+        run: |
+          julia --color=yes --project=climacoupler/experiments/AMIP -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=climacoupler/experiments/AMIP -e 'using Pkg; Pkg.develop(path=".")'
+          julia --color=yes --project=climacoupler/experiments/AMIP -e 'using Pkg; Pkg.precompile()'
+          julia --color=yes --project=climacoupler/experiments/AMIP .buildkite/downstream/climacoupler.jl


### PR DESCRIPTION
To update for the AMIP/CMIP environment split in https://github.com/CliMA/ClimaCoupler.jl/pull/1775. For now I left in the experiments/ClimaEarth/ environment in ClimaCoupler.jl so downstream tests don't break, but it will be removed soon.

## Content
- [x] `experiments/ClimaEarth/` --> `experiments/AMIP/`
- [x] `experiments/ClimaEarth/run_amip.jl` --> `experiments/AMIP/run_simulation.jl`
- [x] `experiments/AMIP/test/runtests.jl` --> `experiments/test/runtests.jl`