### PR TITLE
docs: Fix Wfact in spherical diffusion tutorial

### DIFF
--- a/docs/src/tutorials/diffusion.md
+++ b/docs/src/tutorials/diffusion.md
@@ -139,7 +139,7 @@ grad_matrix = ClimaCore.MatrixFields.operator_matrix(grad_vert)
 
 function Wfact(W, Y, p, dtγ, t)
     @. W.matrix[@name(my_var), @name(my_var)] =
-        dtγ * div_matrix() ⋅ grad_matrix() - (LinearAlgebra.I,)
+        dtγ * K * div_matrix() ⋅ grad_matrix() - (LinearAlgebra.I,)
     return nothing
 end
 


### PR DESCRIPTION
The diffusivity is missing from the Jacobian in the computation of `Wfact`.
Since it is not equal to 1 (K=3 in this example), I am quite sure this will affect the numerical results (in my own code, adding diffusivity gives more reasonable results).

(note: [in the IMEX time stepping tutorial](https://clima.github.io/ClimaTimeSteppers.jl/stable/tutorials/imex_diffusion/#Jacobian-(Wfact)) the diffusivity is included in the Jacobian)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
