### PR TITLE
Remove backward-compat shims for callbacks and type aliases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ main
 - ![][badge-💥breaking] Removed `SciMLBase` and `DiffEqBase` backward-compatibility extensions
   (`ClimaTimeSteppersSciMLExt`, `ClimaTimeSteppersDiffEqExt`) and the `CTS.DiffEqBase` stub module.
   Use `CTS.init`, `CTS.solve`, `CTS.step!`, etc. directly.
+- ![][badge-💥breaking] Removed backward-compatibility aliases `DistributedODEAlgorithm`
+  (use `TimeSteppingAlgorithm`) and `DistributedODEIntegrator` (use `TimeStepperIntegrator`).
+  Removed the `continuous_callbacks` field from `CallbackSet`; use only `discrete_callbacks`.
 
 v0.8.9
 ------

--- a/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
+++ b/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
@@ -24,7 +24,7 @@ Base.zero(A::LDivOverride) = LDivOverride(zero(A.W), A.custom_ldiv!)
 """
     benchmark_step(integrator, [device]; kwargs...)
 
-Benchmarks one step of a `DistributedODEIntegrator` on a specific `ClimaComms`
+Benchmarks one step of a `TimeStepperIntegrator` on a specific `ClimaComms`
 device, along with all user-specified functions that are called during the step,
 and prints a table that summarizes the measurements. Allocation and timing data
 for user-specified functions is rescaled by the number of times they are called
@@ -40,7 +40,7 @@ Available keyword arguments are
    `crop` is `true`
 """
 function CTS.benchmark_step(
-    integrator::CTS.DistributedODEIntegrator,
+    integrator::CTS.TimeStepperIntegrator,
     device::ClimaComms.AbstractDevice = ClimaComms.device();
     with_cu_prof = :bprofile,
     trace = false,

--- a/src/ClimaTimeSteppers.jl
+++ b/src/ClimaTimeSteppers.jl
@@ -67,10 +67,6 @@ Concrete subtypes include [`IMEXAlgorithm`](@ref),
 [`RosenbrockAlgorithm`](@ref).
 """
 abstract type TimeSteppingAlgorithm end
-# COMPAT: ClimaAtmos uses DistributedODEAlgorithm in some call sites.
-# Remove once ClimaAtmos is updated to use TimeSteppingAlgorithm.
-"""Backward-compatible alias for [`TimeSteppingAlgorithm`](@ref)."""
-const DistributedODEAlgorithm = TimeSteppingAlgorithm
 
 abstract type AbstractAlgorithmName end
 
@@ -143,18 +139,14 @@ A collection of [`DiscreteCallback`](@ref)s applied after each step.
 Accepts `nothing`, individual `DiscreteCallback`s, or nested `CallbackSet`s.
 """
 struct CallbackSet{DC <: Tuple}
-    # COMPAT: ClimaDiagnostics accesses .continuous_callbacks as a struct field.
-    # This is always empty — CTS only supports discrete callbacks.
-    # Remove once ClimaDiagnostics is updated to stop reading this field.
-    continuous_callbacks::Tuple{}
     discrete_callbacks::DC
 end
-CallbackSet(cbs::DiscreteCallback...) = CallbackSet((), cbs)
-CallbackSet(::Nothing, cbs::DiscreteCallback...) = CallbackSet((), cbs)
+CallbackSet(cbs::DiscreteCallback...) = CallbackSet(cbs)
+CallbackSet(::Nothing, cbs::DiscreteCallback...) = CallbackSet(cbs)
 CallbackSet(cb::DiscreteCallback, cbs::DiscreteCallback...) =
-    CallbackSet((), (cb, cbs...))
+    CallbackSet((cb, cbs...))
 CallbackSet((; discrete_callbacks)::CallbackSet, cbs::DiscreteCallback...) =
-    CallbackSet((), (discrete_callbacks..., cbs...))
+    CallbackSet((discrete_callbacks..., cbs...))
 
 function initialize_callbacks!(cbset::CallbackSet, u, t, integrator)
     for cb in cbset.discrete_callbacks
@@ -168,10 +160,6 @@ function finalize_callbacks!(cbset::CallbackSet, u, t, integrator)
 end
 
 include("integrators.jl")
-# COMPAT: ClimaAtmos/ClimaCoupler use DistributedODEIntegrator in some call sites.
-# Remove once downstream packages are updated to use TimeStepperIntegrator.
-"""Backward-compatible alias for `TimeStepperIntegrator`."""
-const DistributedODEIntegrator = TimeStepperIntegrator
 
 include("utilities/update_signal_handler.jl")
 include(joinpath("utilities", "async_utils.jl"))

--- a/test/integration/integrator.jl
+++ b/test/integration/integrator.jl
@@ -69,7 +69,7 @@ include(joinpath(@__DIR__, "..", "problems.jl"))
             (false, (; save_everystep = true, stepstop = 0), exact_dt_times[1:1]),
             (false, (; save_everystep = true, stepstop = 4), exact_dt_times[1:5]),
         )
-            is_ode = !(alg isa ClimaTimeSteppers.DistributedODEAlgorithm)
+            is_ode = !(alg isa ClimaTimeSteppers.TimeSteppingAlgorithm)
             is_ode && !compare_to_ode && continue
 
             sol = solve(deepcopy(prob), alg; dt, kwargs...)

--- a/test/utils/convergence_utils.jl
+++ b/test/utils/convergence_utils.jl
@@ -104,7 +104,7 @@ end
 """
     algorithm(algorithm_name, [linear_implicit])
 
-Generates an appropriate `DistributedODEAlgorithm` from an `AbstractAlgorithmName`.
+Generates an appropriate `TimeSteppingAlgorithm` from an `AbstractAlgorithmName`.
 For `IMEXAlgorithmNames`, `linear_implicit` must also be specified. One Newton
 iteration is used for linear implicit problems, and two iterations are used for
 nonlinear implicit problems.


### PR DESCRIPTION
Breaking changes

- Remove `DistributedODEAlgorithm` alias (use `TimeSteppingAlgorithm`)
- Remove `DistributedODEIntegrator` alias (use `TimeStepperIntegrator`)
- Remove `continuous_callbacks` field from `CallbackSet`

Downstream repos already updated:
- ClimaAtmos: DistributedODEIntegrator, continuous_callbacks, CallbackSet
- ClimaDiagnostics: continuous_callbacks, CallbackSet
- ClimaLand: DistributedODEAlgorithm

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
