### PR TITLE
Bugfix: pass float(dt) as dtγ proxy in benchmark ext

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
+++ b/ext/ClimaTimeSteppersBenchmarkToolsExt.jl
@@ -49,6 +49,7 @@ function CTS.benchmark_step(
     only = nothing, # for backward compatibility
 )
     (; u, p, t, dt, alg, cache) = integrator
+    dtγ = float(dt) # proxy for dtγ = float(dt) * a_imp[i, i], used by `Wfact!` and `initialize_imp!`
     if hasproperty(cache, :newtons_method_cache) && !isnothing(cache.newtons_method_cache)
         W = cache.newtons_method_cache.j
     elseif hasproperty(cache, :W)
@@ -119,7 +120,7 @@ function CTS.benchmark_step(
     call_signatures = OrderedCollections.OrderedDict()
     call_signatures["step!"] = (CTS.step!, (integrator,))
     isnothing(W) || (call_signatures["ldiv!"] = (ldiv!, (uₜ, W, u)))
-    isnothing(W) || (call_signatures["Wfact!"] = (T_imp!.Wfact, (W, u, p, dt, t)))
+    isnothing(W) || (call_signatures["Wfact!"] = (T_imp!.Wfact, (W, u, p, dtγ, t)))
     is_default(T_imp!) || (call_signatures["T_imp!"] = (T_imp!, (uₜ, u, p, t)))
     is_default(T_exp_T_lim!) ||
         (call_signatures["T_exp!"] = (T_exp_T_lim!, (uₜ, uₜ, u, p, t)))
@@ -128,7 +129,7 @@ function CTS.benchmark_step(
     is_default(constrain_state!) ||
         (call_signatures["constrain_state!"] = (constrain_state!, (u, p, t)))
     is_default(initialize_imp!) ||
-        (call_signatures["initialize_imp!"] = (initialize_imp!, (u, p, t)))
+        (call_signatures["initialize_imp!"] = (initialize_imp!, (u, p, dtγ)))
     is_default(cache!) || (call_signatures["cache!"] = (cache!, (u, p, t)))
     is_default(cache_imp!) || (call_signatures["cache_imp!"] = (cache_imp!, (u, p, t)))
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Wfact! and initialize_imp! receive dtγ (a plain float) in the real solver path; passing t/dt (ITime) through those hooks was breaking GPU codegen.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
