### PR TITLE
Add post-Newton correction hook to ClimaODEFunction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@ ClimaTimeSteppers.jl Release Notes
 main
 -------
 
+v0.10.4
+-------
+- ![][badge-✨feature/enhancement] Added optional `T_post_imp!(du, u, p, t)` field on
+  `ClimaODEFunction`. When set, it is evaluated on the Newton-solved stage state `U*`
+  (with `cache_imp!` refreshed on `U*` first) and applied as `U ← U* + dtγ · du`.
+  Its contribution is folded into `T_imp[i]` for downstream stage assembly, preserving
+  the ARK scheme structure. Useful for corrections whose dependence on the current state
+  is too nonlinear/discontinuous to include in the Newton solve itself
+  (e.g. upwind corrections where the sign of a velocity may flip during the step).
+
 v0.10.1
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -27,6 +27,25 @@ unnecessary allocations.
 - `T_lim!(du, u, p, t)`: explicit tendency passed through the limiter.
 - `T_exp_T_lim!(du_exp, du_lim, u, p, t)`: fused alternative to separate `T_exp!`/`T_lim!`.
 - `T_imp!`: implicit tendency — typically an [`ClimaTimeSteppers.ODEFunction`](@ref) carrying Jacobian info.
+- `T_post_imp!(du, u, p, t)`: extra tendency evaluated at the Newton-solved stage
+    state `U*` and applied as `U ← U* + dtγ · du`. This is *Lie-Trotter
+    operator splitting* that approximates the fully-implicit stage equation
+    `U = U_start + dtγ · (T_imp(U) + T_post_imp(U))` when including
+    `T_post_imp` in the Newton residual and/or the Jacobian is inconvenient,
+    expensive, or numerically fragile (e.g., upwind corrections where the sign
+    of a velocity may flip during the Newton step). Instead, we solve
+    `U' = U_start + dtγ · T_imp(U')` with Newton and correct
+    `U ← U' + dtγ · T_post_imp(U')`. The splitting error at the stage is
+    `−dtγ² · (J_imp + J_post) · T_post_imp(U*)`, i.e.
+    `O(dtγ² · ‖T_post_imp‖ · ‖J‖)`; because the coefficient scales with
+    `‖T_post_imp‖` rather than the whole `‖T_imp + T_post_imp‖`, it is smaller
+    than what a quasi-Newton solve with the same partial Jacobian would give at
+    `max_iters = 1`. The splitting error does not vanish with additional
+    Newton iterations, so including this option is best reserved for
+    `T_post_imp` terms whose magnitude is genuinely small (grid-scale flux
+    corrections, weak nonlinear closures). The correction is folded into
+    `T_imp[i]` for downstream stage assembly, but does NOT participate in the
+    linear solve.
 
 **Auxiliary functions** (default to no-ops):
 - `lim!(u, p, t, u_ref)`: limiter applied after incrementing `u` from `u_ref` by `T_lim!`.
@@ -52,6 +71,7 @@ Use `UpdateEveryN(n, ...)` to skip every N-th call; see [`UpdateSignalHandler`](
 # Fields
 - `T_exp_T_lim!`: fused explicit tendency function (built from `T_exp!`/`T_lim!` at construction).
 - `T_imp!`: implicit tendency function (or `nothing`).
+- `T_post_imp!`: post-Newton correction tendency function (or `nothing`).
 - `lim!`: monotonicity limiter.
 - `dss!`: direct stiffness summation operator.
 - `constrain_state!`: physical-constraint enforcer.
@@ -64,6 +84,7 @@ Use `UpdateEveryN(n, ...)` to skip every N-th call; see [`UpdateSignalHandler`](
 - `HasExp` (type parameter): `true` when there is an explicit tendency.
 - `HasExpLim` (type parameter): `true` when there is a fused explicit/limiter tendency.
 - `HasImp` (type parameter): `true` when there is an implicit tendency.
+- `HasPostImp` (type parameter): `true` when there is a post-Newton correction tendency.
 
 Internally, `T_exp!` and `T_lim!` are merged into a single `T_exp_T_lim!`
 at construction time.
@@ -84,6 +105,7 @@ f = ClimaODEFunction(; T_exp!, T_imp! = T_imp)
 struct ClimaODEFunction{
     TEL,
     TI,
+    TPI,
     L,
     D,
     CS,
@@ -96,10 +118,12 @@ struct ClimaODEFunction{
     HasExp,
     HasExpLim,
     HasImp,
+    HasPostImp,
 } <:
        AbstractClimaODEFunction
     T_exp_T_lim!::TEL
     T_imp!::TI
+    T_post_imp!::TPI
     lim!::L
     dss!::D
     constrain_state!::CS
@@ -113,6 +137,7 @@ struct ClimaODEFunction{
         T_lim! = nothing,
         T_exp! = nothing,
         T_imp! = nothing,
+        T_post_imp! = nothing,
         lim! = Returns(nothing),
         dss! = Returns(nothing),
         constrain_state! = Returns(nothing),
@@ -153,9 +178,11 @@ struct ClimaODEFunction{
         end
         _has_exp_lim = !isnothing(T_exp_T_lim!)
         _has_imp = !isnothing(T_imp!)
+        _has_post_imp = !isnothing(T_post_imp!)
         args = (
             T_exp_T_lim!,
             T_imp!,
+            T_post_imp!,
             lim!,
             dss!,
             constrain_state!,
@@ -165,7 +192,11 @@ struct ClimaODEFunction{
             update_cache,
             update_constrain_state,
         )
-        return new{typeof.(args)..., _has_lim, _has_exp, _has_exp_lim, _has_imp}(args...)
+        return new{
+            typeof.(args)..., _has_lim, _has_exp, _has_exp_lim, _has_imp, _has_post_imp,
+        }(
+            args...,
+        )
     end
 end
 
@@ -173,7 +204,8 @@ end
 has_T_exp(f) = !isnothing(f.T_exp_T_lim!)
 has_T_exp(
     ::ClimaODEFunction{
-        <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, HasExp,
+        <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+        HasExp,
     },
 ) where {HasExp} = HasExp
 
@@ -181,7 +213,7 @@ has_T_exp(
 has_T_lim(f) = false
 has_T_lim(
     ::ClimaODEFunction{
-        <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, HasLim,
+        <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, HasLim,
     },
 ) where {HasLim} = HasLim
 
@@ -190,7 +222,7 @@ has_T_exp_T_lim(f) = !isnothing(f.T_exp_T_lim!)
 has_T_exp_T_lim(
     ::ClimaODEFunction{
         <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
-        HasExpLim,
+        <:Any, HasExpLim,
     },
 ) where {HasExpLim} = HasExpLim
 
@@ -199,9 +231,18 @@ has_T_imp(f) = !isnothing(f.T_imp!)
 has_T_imp(
     ::ClimaODEFunction{
         <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
-        <:Any, HasImp,
+        <:Any, <:Any, HasImp,
     },
 ) where {HasImp} = HasImp
+
+"""Return `true` when the ODE function has a post-Newton correction tendency."""
+has_T_post_imp(f) = !isnothing(f.T_post_imp!)
+has_T_post_imp(
+    ::ClimaODEFunction{
+        <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any,
+        <:Any, <:Any, <:Any, HasPostImp,
+    },
+) where {HasPostImp} = HasPostImp
 
 """
     initialize_function!(f, u0, p, t0)

--- a/src/solvers/imex_ark.jl
+++ b/src/solvers/imex_ark.jl
@@ -226,6 +226,17 @@ Shared by the IMEX-ARK and IMEX-SSPRK stage loops.
         T_imp!, newtons_method, newtons_method_cache, cache_imp!,
     )
 
+    # Post-Newton correction (optional): evaluate `T_post_imp!` on the
+    # Newton-solved `U` and apply `U ← U + dtγ · dY_post`. The correction
+    # is folded into `T_imp[i]` by the downstream `(U − temp) / dtγ`
+    # computation, and inherits the same `b_imp` weighting, so the ARK
+    # scheme structure is preserved. Use `cache.T_imp[i]` as scratch.
+    if has_T_post_imp(f)
+        cache_imp!(U, p, t_imp)
+        f.T_post_imp!(cache.T_imp[i], U, p, t_imp)
+        @. U += dtγ * cache.T_imp[i]
+    end
+
     # Post-Newton: DSS the solved stage value. Fire `EndOfStageSignal` for
     # `cache!` / `constrain_state!`, EXCEPT at the last stage of an FSAL
     # tableau (where `u ≡ U_s` and end-of-step handles it). When `cache!`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,10 @@ end
     include("unit/initialize_imp.jl")
 end
 
+@safetestset "T_post_imp!" begin
+    include("unit/post_imp.jl")
+end
+
 @safetestset "Edge cases" begin
     include("unit/edge_cases.jl")
 end

--- a/test/unit/post_imp.jl
+++ b/test/unit/post_imp.jl
@@ -1,0 +1,65 @@
+#=
+The optional post-Newton hook `T_post_imp!` (a public field of `ClimaODEFunction`)
+is evaluated at the Newton-solved stage state `U*` and applied as
+`U ← U* + dtγ · dY_post`. It must be honored by BOTH the IMEX-ARK and the
+IMEX-SSPRK stepping paths, and must NOT be called when the field is `nothing`.
+=#
+using ClimaTimeSteppers, LinearAlgebra, Test
+import ClimaTimeSteppers as CTS
+import ClimaTimeSteppers: ODEProblem, ODEFunction
+
+@testset "T_post_imp! is honored on both IMEX paths" begin
+    n = 3
+    Id = Matrix{Float64}(I, n, n)
+    # T_imp!(du,u,p,t) = -u  ⟹  J = -I  ⟹  W = dtγ J - I = -(dtγ + 1) I
+    # T_post_imp!(du,u,p,t) = c · u — small linear correction, counted per call.
+    function make_prob(calls; use_post = true, c = 0.05)
+        T_post_imp! = use_post ? ((du, u, p, t) -> (du .= c .* u; calls[] += 1)) : nothing
+        ODEProblem(
+            ClimaODEFunction(;
+                T_exp! = (du, u, p, t) -> (du .= 0.1 .* u),
+                T_imp! = ODEFunction(
+                    (du, u, p, t) -> (du .= -u);
+                    jac_prototype = zeros(n, n),
+                    Wfact = (W, u, p, dtγ, t) -> (W .= -dtγ .* Id .- Id),
+                ),
+                T_post_imp!,
+            ),
+            ones(n),
+            (0.0, 1.0),
+            nothing,
+        )
+    end
+
+    # SSP333 exercises the SSPRK path; ARS343 exercises the ARK path.
+    for name in (SSP333(), ARS343())
+        # With `T_post_imp!`: hook is called; solution stays finite.
+        calls = Ref(0)
+        prob = make_prob(calls; use_post = true)
+        alg = CTS.IMEXAlgorithm(name, NewtonsMethod(; max_iters = 2))
+        integrator = CTS.init(prob, alg; dt = 0.1)
+        CTS.step!(integrator)
+        @test calls[] > 0                     # hook fired at implicit stages
+        @test all(isfinite, integrator.u)
+
+        # Without `T_post_imp!`: hook must NOT fire (default is `nothing`).
+        calls_off = Ref(0)
+        prob_off = make_prob(calls_off; use_post = false)
+        integrator_off = CTS.init(prob_off, alg; dt = 0.1)
+        CTS.step!(integrator_off)
+        @test calls_off[] == 0
+
+        # With a nonzero correction the result must differ from the no-post run.
+        @test integrator.u != integrator_off.u
+
+        # Quantitative sanity: with a zero-coefficient `T_post_imp!` the hook
+        # writes du = 0, so `U ← U* + dtγ · 0 = U*` at every stage and the
+        # result must be bitwise-identical to the `use_post = false` run.
+        calls_zero = Ref(0)
+        prob_zero = make_prob(calls_zero; use_post = true, c = 0.0)
+        integrator_zero = CTS.init(prob_zero, alg; dt = 0.1)
+        CTS.step!(integrator_zero)
+        @test calls_zero[] > 0                # hook still fires
+        @test integrator_zero.u == integrator_off.u
+    end
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add an optional `T_post_imp!(du, u, p, t)` field on `ClimaODEFunction`. When set, it's evaluated on the Newton-solved stage state `U*` and applied as `U ← U* + dtγ · du` inside `solve_stage_implicit!` (shared by IMEX-ARK and IMEX-SSPRK). The correction is folded into `T_imp[i]` via the existing `(U − U_start) / dtγ` computation, so it inherits the same `b_imp` weight and ARK order conditions are preserved.
  
## Motivation
This is meant for corrections whose dependence on the current state is too nonlinear or discontinuous to include in the Newton solve itself. The motivating case (in downstream ClimaAtmos) is the ρe_tot / ρq_tot vertical upwind correction: with `max_iters = 1`, the sign of `ᶠu³` can flip between Newton's initial guess and its solution, so an upwind flux baked into `T_imp!` at the initial guess can end up using values from the wrong cell. Evaluating the correction post-Newton, on `U*`, fixes the direction.

## Design notes
- **`cache_imp!` is refreshed on `U*` before `T_post_imp!` runs.** `solve_newton!` only calls `prepare_for_f!` (== `cache_imp!`) before each residual evaluation, not after the final `x .-= Δx` step, so `p.precomputed` would otherwise be one Newton step stale — exactly the quantities (e.g. `ᶠu³`) that the correction needs.
- **Scratch buffer.** The correction is written into `cache.T_imp[i]`, which is guaranteed to exist for implicit stages (`a_imp[i,i] ≠ 0`) and is about to be overwritten by `evaluate_stage_tendencies!` anyway.
- **Zero cost when unused.** Everything is gated on `has_T_post_imp(f)`.
- **Order conditions.** The correction is not part of the Newton residual, so we don't converge to `U = U_start + dtγ · (T_imp(U) + T_post(U))` — we get `U = U_start + dtγ · T_imp_Newton(U*) + dtγ · T_post(U*)`. This is an operator-splitting-style step. The formal Butcher-tree order matches standard ARK; practically, order is preserved as long as `T_post` is small and non-stiff.

## Changes
- `src/functions.jl` — new `T_post_imp!` field + `TPI` type parameter, updated docstring, `has_T_post_imp` accessor. Shifted `<:Any` filler counts in `has_T_exp` / `has_T_lim` / `has_T_exp_T_lim` / `has_T_imp`.
- `src/solvers/imex_ark.jl` — inserted the refresh + hook + apply block between Newton and the post-Newton DSS in the shared `solve_stage_implicit!`.
- `test/unit/post_imp.jl` (new) + `test/runtests.jl` — asserts the hook fires on both `SSP333` (SSPRK) and `ARS343` (ARK), stays finite, does NOT fire when the field is `nothing`, and produces a different result than the no-hook run.
  - `NEWS.md` — new `v0.10.4` section.
  - `Project.toml` — `0.10.3 → 0.10.4`.
