### PR TITLE
bugfix: Rosenbrock falls back to cache_imp! when cache! is skipped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@ ClimaTimeSteppers.jl Release Notes
 main
 -------
 
+v0.10.5
+-------
+- ![][badge-🐛bugfix] `RosenbrockAlgorithm` now falls back to `cache_imp!` at intermediate
+  stages when `update_cache` does not fire `cache!` (e.g. `UpdateEvery(EndOfStep)`).
+  Previously, `T_imp!` / `T_exp_T_lim!` at stages ≥ 2 could be evaluated against a
+  stale `p.precomputed`, producing an incorrect linear-solve RHS. Mirrors the ARK /
+  SSPRK post-Newton fallback in `solve_stage_implicit!`.
+
 v0.10.4
 -------
 - ![][badge-✨feature/enhancement] Added optional `T_post_imp!(du, u, p, t)` field on

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/src/solvers/rosenbrock.jl
+++ b/src/solvers/rosenbrock.jl
@@ -160,7 +160,7 @@ function step_u!(int, cache::RosenbrockCache{Nstages}) where {Nstages}
     T_exp_T_lim! = f.T_exp_T_lim!
     tgrad! = !has_T_imp(f) ? nothing : T_imp!.tgrad
 
-    (; cache!, dss!, constrain_state!) = f
+    (; cache!, cache_imp!, dss!, constrain_state!) = f
     (; update_cache, update_constrain_state) = f
 
     # TODO: This is only valid when Γ[i, i] is constant, otherwise we have to
@@ -206,12 +206,20 @@ function step_u!(int, cache::RosenbrockCache{Nstages}) where {Nstages}
         # operations ensures that the state is always continuous and
         # consistent with the cache, including between timesteps.
         # State is ready for tendency evaluation right after assembly + DSS;
-        # fire `EndOfStageSignal` (subtype of `WithDSS`).
+        # fire `EndOfStageSignal` (subtype of `WithDSS`). When `cache!` is
+        # skipped by policy (e.g. `UpdateEvery(EndOfStep)`), fall back to
+        # `cache_imp!` so the implicit-relevant cache tracks the stage
+        # state used by `T_imp!` and the linear solve — mirrors the ARK
+        # / SSPRK post-Newton fallback in `solve_stage_implicit!`.
         if i != 1
             dss!(U, p, t + αi * dt)
             needs_update!(update_constrain_state, EndOfStageSignal()) &&
                 constrain_state!(U, p, t + αi * dt)
-            needs_update!(update_cache, EndOfStageSignal()) && cache!(U, p, t + αi * dt)
+            if needs_update!(update_cache, EndOfStageSignal())
+                cache!(U, p, t + αi * dt)
+            else
+                cache_imp!(U, p, t + αi * dt)
+            end
         end
 
         if has_T_imp(f)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
bugfix: Rosenbrock falls back to cache_imp! when cache! is skipped

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
