### PR TITLE
feat: add the trapezoidal step-exchange outer and an optional implicit complement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaTimeSteppers.jl Release Notes
 main
 -------
 
+- ![][badge-✨feature/enhancement] Added `TrapezoidalSplitOuter`, a second-order
+  step-exchange outer method: the slow forcing is averaged between the step
+  start and a predicted step end, and the fast system sub-cycles the full step
+  with the averaged forcing.
+
 - ![][badge-✨feature/enhancement] Added a step-exchange multirate outer family
   with its first member, `LieSplitOuter`, usable as the `slow` argument to
   `Multirate` alongside the stage-exchange methods. The fast component of the

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaTimeSteppers.jl Release Notes
 main
 -------
 
+- ![][badge-✨feature/enhancement] Added an optional outer implicit complement
+  to the step-exchange outer methods: a callable `(u, p, t, dt) -> nothing`
+  advancing `u` in place, called once over the step by `LieSplitOuter` and as
+  two half-step calls bracketing the sub-cycle (Strang splitting) by
+  `TrapezoidalSplitOuter`.
+
 - ![][badge-✨feature/enhancement] Added `TrapezoidalSplitOuter`, a second-order
   step-exchange outer method: the slow forcing is averaged between the step
   start and a predicted step end, and the fast system sub-cycles the full step

--- a/docs/src/algorithm_formulations/mrrk.md
+++ b/docs/src/algorithm_formulations/mrrk.md
@@ -112,24 +112,29 @@ The methods above are *stage-exchange*: they re-evaluate the slow tendency $f_S$
 The *step-exchange* family instead evaluates $f_S$ only at whole-step states and keeps it fixed while the fast system integrates the full step.
 This is the split-explicit composition used by atmospheric dynamical cores, where the slow tendency is the expensive physics and the fast tendency is the acoustic or gravity-wave subsystem.
 
+Two outer methods are provided, distinguished by the operator-splitting order:
+
 | Algorithm | Slow evaluations per step | Order |
 |:---|:---|:---|
 | `LieSplitOuter` | 1 | 1 |
+| `TrapezoidalSplitOuter` | 2 | 2 |
 
 `LieSplitOuter` freezes $f_S$ at the step start and sub-cycles the fast system once over $\Delta t$.
+`TrapezoidalSplitOuter` freezes $f_S$ at the step start, sub-cycles to a predicted end state, re-evaluates $f_S$ there, averages the two, and sub-cycles again with the averaged forcing.
+The second sub-cycle restarts from the step-start state after a full `cache!` refresh at that state, so the predicted-state forcing evaluation does not leave the cache paired with a state one step ahead.
 
 The fast component `f1` of the `SplitODEProblem` is a full `ClimaODEFunction`, so the inner sub-cycle can be implicit-explicit: a vertically-implicit acoustic solve with its own Jacobian, Newton iteration, and limiter.
 The frozen forcing is a pair `(G, G_lim)`: the unlimited part is added to the inner explicit tendency and the limited part is passed to the inner limiter, mirroring the split of the inner function.
 
-The step is sub-divided by integer division of `dt` into the fast sub-step size.
+The step is sub-divided by integer division of `dt`: the fast sub-step size and, for `TrapezoidalSplitOuter`, the half-step `dt / 2`.
 For a floating-point `dt` this is ordinary division; for an `ITime` `dt` it uses the exact integer division provided by ClimaUtilities, which refines the period when needed and errors when the step cannot be divided exactly.
 
 ### Choosing a family
 
 The families differ in where the fast and slow components exchange information.
 A stage-exchange method evaluates the slow tendency at stage-level intermediate states and integrates the fast system over partial stage intervals.
-A step-exchange method evaluates the slow tendency only at whole-step states and holds each evaluation frozen while the fast system integrates the full step.
-The evaluation count is therefore set by the order of the outer combination rather than by a stage structure.
+A step-exchange method evaluates the slow tendency only at whole-step states, once per step for `LieSplitOuter` and twice (step start and a full-step predictor state) for `TrapezoidalSplitOuter`, and holds each evaluation frozen while the fast system integrates the full step.
+The evaluation count is therefore set by the order of the outer combination rather than by a stage structure, and is comparable to a low-stage-count stage-exchange method at second order.
 Choose stage exchange when fast and slow accuracy are coupled through the stages; choose step exchange when the slow tendency is expensive and should be evaluated at whole-step states only.
 
 ### Relation to the literature

--- a/docs/src/algorithm_formulations/mrrk.md
+++ b/docs/src/algorithm_formulations/mrrk.md
@@ -129,13 +129,19 @@ The frozen forcing is a pair `(G, G_lim)`: the unlimited part is added to the in
 The step is sub-divided by integer division of `dt`: the fast sub-step size and, for `TrapezoidalSplitOuter`, the half-step `dt / 2`.
 For a floating-point `dt` this is ordinary division; for an `ITime` `dt` it uses the exact integer division provided by ClimaUtilities, which refines the period when needed and errors when the step cannot be divided exactly.
 
+Each step-exchange outer method has an optional *outer implicit complement*, a callable `(u, p, t, dt) -> nothing` advancing `u` in place.
+It models an inner/outer implicit split where the inner integrator solves a restricted implicit operator and the complement solves the remainder as an outer implicit sub-step.
+`LieSplitOuter` calls it once over $\Delta t$; `TrapezoidalSplitOuter` brackets the sub-cycle with two half-step calls (Strang splitting).
+Before the second complement call, `TrapezoidalSplitOuter` refreshes the full cache at the sub-cycled end state, so the complement solve is paired with a cache consistent with its input state.
+The application provides the complement; the outer method only sequences it.
+
 ### Choosing a family
 
 The families differ in where the fast and slow components exchange information.
 A stage-exchange method evaluates the slow tendency at stage-level intermediate states and integrates the fast system over partial stage intervals.
 A step-exchange method evaluates the slow tendency only at whole-step states, once per step for `LieSplitOuter` and twice (step start and a full-step predictor state) for `TrapezoidalSplitOuter`, and holds each evaluation frozen while the fast system integrates the full step.
 The evaluation count is therefore set by the order of the outer combination rather than by a stage structure, and is comparable to a low-stage-count stage-exchange method at second order.
-Choose stage exchange when fast and slow accuracy are coupled through the stages; choose step exchange when the slow tendency is expensive and should be evaluated at whole-step states only.
+Choose stage exchange when fast and slow accuracy are coupled through the stages; choose step exchange when the slow tendency is expensive and should be evaluated at whole-step states only, or when the composition needs an outer implicit complement.
 
 ### Relation to the literature
 

--- a/docs/src/api/ode_solvers.md
+++ b/docs/src/api/ode_solvers.md
@@ -185,6 +185,7 @@ WSRK3
 ### Step-exchange (split-explicit)
 ```@docs
 LieSplitOuter
+TrapezoidalSplitOuter
 ```
 
 ## Rosenbrock Methods

--- a/src/solvers/multirate.jl
+++ b/src/solvers/multirate.jl
@@ -20,6 +20,7 @@ the fast system integrates the full step.
   - [`MultirateInfinitesimalStep`](@ref) (stage-exchange)
   - [`WickerSkamarockRungeKutta`](@ref) (stage-exchange)
   - [`LieSplitOuter`](@ref) (step-exchange)
+  - [`TrapezoidalSplitOuter`](@ref) (step-exchange)
 
 Pass `fast_dt` as a keyword argument to [`init`](@ref) or [`solve`](@ref)
 to set the inner timestep.
@@ -42,7 +43,7 @@ sol  = CTS.solve(prob, alg; dt = 0.1, fast_dt = 0.01)
 # Step-exchange: `f_fast` is a full `ClimaODEFunction`, `freeze!` fills the
 # frozen slow forcing pair, and the inner sub-cycle is implicit-explicit.
 prob = CTS.SplitODEProblem(f_fast, freeze!, u0, tspan, p)
-alg  = Multirate(IMEXAlgorithm(ARS343(), NewtonsMethod()), LieSplitOuter())
+alg  = Multirate(IMEXAlgorithm(ARS343(), NewtonsMethod()), TrapezoidalSplitOuter())
 sol  = CTS.solve(prob, alg; dt = 0.1, fast_dt = 0.1 / 4)
 ```
 """

--- a/src/solvers/split_outer.jl
+++ b/src/solvers/split_outer.jl
@@ -1,4 +1,4 @@
-export LieSplitOuter
+export LieSplitOuter, TrapezoidalSplitOuter
 
 #####
 ##### Step-exchange multirate outer methods. See
@@ -8,7 +8,8 @@ export LieSplitOuter
 """
     StepExchangeOuter
 
-Supertype for the step-exchange outer methods, used as the `slow` argument to
+Supertype for the step-exchange outer methods [`LieSplitOuter`](@ref) and
+[`TrapezoidalSplitOuter`](@ref), used as the `slow` argument to
 [`Multirate`](@ref).
 """
 abstract type StepExchangeOuter <: TimeSteppingAlgorithm end
@@ -22,6 +23,15 @@ start and sub-cycle the fast system once over the whole step.
 struct LieSplitOuter <: StepExchangeOuter end
 
 """
+    TrapezoidalSplitOuter()
+
+Second-order step-exchange outer method: average the slow forcing between the
+step start and a predicted step end, then sub-cycle the fast system over the
+whole step with the averaged forcing.
+"""
+struct TrapezoidalSplitOuter <: StepExchangeOuter end
+
+"""
     DualOffsetODEFunction(f, G, G_lim)
 
 Wrap a fused explicit/limited tendency `f(du_exp, du_lim, u, p, t)` and add a
@@ -30,7 +40,8 @@ output. Generalizes [`OffsetODEFunction`](@ref) to the two-output
 (explicit, limited) form used by the step-exchange inner sub-cycle, so the
 inner limiter is applied to the limited forcing.
 
-`G` and `G_lim` are aliased, not copied; the outer step mutates them in place.
+`G` and `G_lim` are aliased, not copied; the outer step mutates them in place
+between sub-cycles.
 """
 struct DualOffsetODEFunction{F, A}
     f::F
@@ -45,7 +56,7 @@ function (o::DualOffsetODEFunction)(du_exp, du_lim, u, p, t)
 end
 
 """
-    StepExchangeOuterCache{O, FR, FF, B, DT}
+    StepExchangeOuterCache{O, FR, FF, B, B2, DT}
 
 Workspace for a step-exchange [`Multirate`](@ref) method.
 
@@ -58,16 +69,34 @@ Workspace for a step-exchange [`Multirate`](@ref) method.
   `constrain_state!` is applied once per outer step under its
   `update_constrain_state` handler.
 - `G`, `G_lim`: frozen forcing pair, aliased into the inner sub-cycle's forcing.
+- `G2`, `G2_lim`: second-pass forcing pair for `TrapezoidalSplitOuter`; `nothing`
+  for `LieSplitOuter`.
+- `U0`: outer-step-start state for `TrapezoidalSplitOuter`; `nothing` for
+  `LieSplitOuter`.
 - `fast_dt`: inner sub-step size.
 """
-struct StepExchangeOuterCache{O <: StepExchangeOuter, FR, FF, B, DT}
+struct StepExchangeOuterCache{O <: StepExchangeOuter, FR, FF, B, B2, DT}
     outer::O
     freeze!::FR
     fast_fn::FF
     G::B
     G_lim::B
+    G2::B2
+    G2_lim::B2
+    U0::B2
     fast_dt::DT
 end
+
+"""
+    second_pass_buffers(outer, u0)
+
+Allocate the second-pass forcing pair and step-start state used by the
+`TrapezoidalSplitOuter` step path, returning `nothing` for `LieSplitOuter`,
+which does not use them.
+"""
+second_pass_buffers(::LieSplitOuter, u0) = (nothing, nothing, nothing)
+second_pass_buffers(::TrapezoidalSplitOuter, u0) =
+    (zero(u0), zero(u0), zero(u0))
 
 function init_cache(
     prob::ODEProblem,
@@ -78,12 +107,16 @@ function init_cache(
 ) where {F}
     @assert prob.f isa SplitFunction
     u0 = prob.u0
+    G2, G2_lim, U0 = second_pass_buffers(alg.slow, u0)
     outercache = StepExchangeOuterCache(
         alg.slow,
         prob.f.f2,
         prob.f.f1,
         zero(u0),
         zero(u0),
+        G2,
+        G2_lim,
+        U0,
         fast_dt,
     )
     innerfun = init_inner(prob, outercache)
@@ -142,6 +175,29 @@ function step_split_outer!(int, cache, outer::LieSplitOuter)
 
     freeze!(G, G_lim, u, p, t)
     subcycle!(innerinteg, fast_fn.cache_imp!, u, p, t, dt, fast_dt)
+    u .= innerinteg.u
+    needs_update!(fast_fn.update_constrain_state, EndOfStepSignal()) &&
+        fast_fn.constrain_state!(u, p, t + dt)
+    fast_fn.cache!(u, p, t + dt)
+    return u
+end
+
+function step_split_outer!(int, cache, outer::TrapezoidalSplitOuter)
+    (; outercache, innerinteg) = cache
+    (; freeze!, fast_fn, G, G_lim, G2, G2_lim, U0, fast_dt) = outercache
+    (; u, p, t, dt) = int
+    cache_imp! = fast_fn.cache_imp!
+
+    U0 .= u
+    freeze!(G, G_lim, U0, p, t)
+    subcycle!(innerinteg, cache_imp!, U0, p, t, dt, fast_dt)
+    freeze!(G2, G2_lim, innerinteg.u, p, t + dt)
+    @. G = (G + G2) / 2
+    @. G_lim = (G_lim + G2_lim) / 2
+    # The second-pass freeze evaluates the predicted end state; refresh the
+    # full cache at the second-pass restart state before the second sub-cycle.
+    fast_fn.cache!(U0, p, t)
+    subcycle!(innerinteg, cache_imp!, U0, p, t, dt, fast_dt)
     u .= innerinteg.u
     needs_update!(fast_fn.update_constrain_state, EndOfStepSignal()) &&
         fast_fn.constrain_state!(u, p, t + dt)

--- a/src/solvers/split_outer.jl
+++ b/src/solvers/split_outer.jl
@@ -15,21 +15,35 @@ Supertype for the step-exchange outer methods [`LieSplitOuter`](@ref) and
 abstract type StepExchangeOuter <: TimeSteppingAlgorithm end
 
 """
-    LieSplitOuter()
+    LieSplitOuter(complement = nothing)
 
 First-order step-exchange outer method: freeze the slow forcing at the step
 start and sub-cycle the fast system once over the whole step.
+
+`complement` is an optional outer implicit complement `(u, p, t, dt) -> nothing`
+that advances `u` in place; the outer step calls it once over `dt` before the
+sub-cycle. `nothing` disables it.
 """
-struct LieSplitOuter <: StepExchangeOuter end
+struct LieSplitOuter{C} <: StepExchangeOuter
+    complement::C
+end
+LieSplitOuter() = LieSplitOuter(nothing)
 
 """
-    TrapezoidalSplitOuter()
+    TrapezoidalSplitOuter(complement = nothing)
 
 Second-order step-exchange outer method: average the slow forcing between the
 step start and a predicted step end, then sub-cycle the fast system over the
 whole step with the averaged forcing.
+
+`complement` is an optional outer implicit complement `(u, p, t, dt) -> nothing`
+that advances `u` in place; the outer step brackets the sub-cycle with two
+half-step calls (Strang splitting). `nothing` disables it.
 """
-struct TrapezoidalSplitOuter <: StepExchangeOuter end
+struct TrapezoidalSplitOuter{C} <: StepExchangeOuter
+    complement::C
+end
+TrapezoidalSplitOuter() = TrapezoidalSplitOuter(nothing)
 
 """
     DualOffsetODEFunction(f, G, G_lim)
@@ -61,7 +75,8 @@ end
 Workspace for a step-exchange [`Multirate`](@ref) method.
 
 # Fields
-- `outer`: the [`StepExchangeOuter`](@ref) method.
+- `outer`: the [`StepExchangeOuter`](@ref) method, with the optional
+  complement.
 - `freeze!`: `freeze!(G, G_lim, U, p, t)` fills the frozen forcing pair at
   state `U`.
 - `fast_fn`: the fast `ClimaODEFunction`; `cache!` refreshes the full cache at
@@ -172,7 +187,9 @@ function step_split_outer!(int, cache, outer::LieSplitOuter)
     (; outercache, innerinteg) = cache
     (; freeze!, fast_fn, G, G_lim, fast_dt) = outercache
     (; u, p, t, dt) = int
+    complement = outer.complement
 
+    isnothing(complement) || complement(u, p, t, dt)
     freeze!(G, G_lim, u, p, t)
     subcycle!(innerinteg, fast_fn.cache_imp!, u, p, t, dt, fast_dt)
     u .= innerinteg.u
@@ -187,7 +204,13 @@ function step_split_outer!(int, cache, outer::TrapezoidalSplitOuter)
     (; freeze!, fast_fn, G, G_lim, G2, G2_lim, U0, fast_dt) = outercache
     (; u, p, t, dt) = int
     cache_imp! = fast_fn.cache_imp!
+    complement = outer.complement
 
+    # `dt / 2` is only needed for the complement half-steps; compute it there so
+    # a `nothing` complement never divides `dt`.
+    if !isnothing(complement)
+        complement(u, p, t, dt / 2)
+    end
     U0 .= u
     freeze!(G, G_lim, U0, p, t)
     subcycle!(innerinteg, cache_imp!, U0, p, t, dt, fast_dt)
@@ -199,6 +222,12 @@ function step_split_outer!(int, cache, outer::TrapezoidalSplitOuter)
     fast_fn.cache!(U0, p, t)
     subcycle!(innerinteg, cache_imp!, U0, p, t, dt, fast_dt)
     u .= innerinteg.u
+    if !isnothing(complement)
+        # The sub-cycle refreshes only the implicit cache; refresh the full
+        # cache at the sub-cycled end state before the second complement call.
+        fast_fn.cache!(u, p, t + dt)
+        complement(u, p, t + dt / 2, dt / 2)
+    end
     needs_update!(fast_fn.update_constrain_state, EndOfStepSignal()) &&
         fast_fn.constrain_state!(u, p, t + dt)
     fast_fn.cache!(u, p, t + dt)

--- a/test/solvers/multirate_step_exchange.jl
+++ b/test/solvers/multirate_step_exchange.jl
@@ -159,6 +159,43 @@ end
         @test norm(limited.u .- exact_solution(args.dt * args.n_steps)) < 5.0e-3
     end
 
+    @testset "complement sequencing" begin
+        dt = 0.1
+        fast_dt = dt / 4
+        n_steps = 3
+        shift = [0.05, -0.02]
+
+        lie_calls = Tuple{Float64, Float64}[]
+        lie_complement = function (u, p, t, dt)
+            push!(lie_calls, (t, dt))
+            @. u += shift * dt
+            return nothing
+        end
+        lie = run_step_exchange(LieSplitOuter(lie_complement); dt, fast_dt, n_steps)
+        lie_ref = run_step_exchange(LieSplitOuter(); dt, fast_dt, n_steps)
+        # Lie applies the complement once per step over the full step.
+        @test length(lie_calls) == n_steps
+        @test all(c -> c[2] == dt, lie_calls)
+        @test lie_calls[1][1] == 0.0
+        @test lie.u != lie_ref.u
+
+        trap_calls = Tuple{Float64, Float64}[]
+        trap_complement = function (u, p, t, dt)
+            push!(trap_calls, (t, dt))
+            @. u += shift * dt
+            return nothing
+        end
+        trap =
+            run_step_exchange(TrapezoidalSplitOuter(trap_complement); dt, fast_dt, n_steps)
+        trap_ref = run_step_exchange(TrapezoidalSplitOuter(); dt, fast_dt, n_steps)
+        # Trapezoidal brackets each step with two half-step complement calls.
+        @test length(trap_calls) == 2 * n_steps
+        @test all(c -> c[2] == dt / 2, trap_calls)
+        @test trap_calls[1][1] == 0.0
+        @test trap_calls[2][1] == dt / 2
+        @test trap.u != trap_ref.u
+    end
+
     @testset "trapezoidal second-pass cache refresh" begin
         dt = 0.1
         log = []
@@ -189,6 +226,32 @@ end
         @test log[restart].u == log[mid].u
         @test log[final].t == dt
         @test log[final].u == integ.u
+    end
+
+    @testset "trapezoidal second-complement cache refresh" begin
+        dt = 0.1
+        log = []
+        complement = function (u, p, t, dt_c)
+            push!(log, (; hook = :complement, t, u = copy(u)))
+            return nothing
+        end
+        (; integ) = step_exchange_integrator(
+            TrapezoidalSplitOuter(complement);
+            log,
+            dt,
+            fast_dt = dt / 4,
+            n_steps = 1,
+        )
+        CTS.step!(integ)
+        complements = findall(e -> e.hook == :complement, log)
+        @test length(complements) == 2
+        full = findall(e -> e.hook == :cache, log)
+        # A full cache refresh occurs before the second complement call, paired
+        # with the sub-cycled end state and time.
+        refresh = findlast(<(complements[2]), full)
+        @test refresh !== nothing
+        @test log[full[refresh]].t == dt
+        @test log[full[refresh]].u == log[complements[2]].u
     end
 
     @testset "T_post_imp! threading" begin

--- a/test/solvers/multirate_step_exchange.jl
+++ b/test/solvers/multirate_step_exchange.jl
@@ -29,11 +29,14 @@ exact_solution(t) = exp(A_total .* t) * Y0
 # `route_lim` places the frozen slow forcing in the limited output `G_lim`
 # (applied through the inner `lim!`) instead of the unlimited output `G`; the
 # counters record how often the slow-forcing freeze and the limiter are called.
+# When `log` is a vector, each `freeze!`, `cache!`, and `cache_imp!` call
+# appends `(; hook, t, u)` with a copy of the state it was given.
 function step_exchange_integrator(
     outer;
     route_lim = false,
     constrain_state! = Returns(nothing),
     T_post_imp! = nothing,
+    log = nothing,
     dt,
     fast_dt,
     n_steps,
@@ -41,6 +44,10 @@ function step_exchange_integrator(
     freeze_count = Ref(0)
     lim_count = Ref(0)
     scratch = zeros(2)
+    record(hook) = function (u, p, t)
+        isnothing(log) || push!(log, (; hook, t, u = copy(u)))
+        return nothing
+    end
 
     fast! = function (du_exp, du_lim, u, p, t)
         mul!(du_exp, A_exp, u)
@@ -61,8 +68,8 @@ function step_exchange_integrator(
         T_exp_T_lim! = fast!,
         T_imp!,
         T_post_imp!,
-        cache! = Returns(nothing),
-        cache_imp! = Returns(nothing),
+        cache! = record(:cache),
+        cache_imp! = record(:cache_imp),
         lim!,
         dss! = Returns(nothing),
         constrain_state!,
@@ -70,6 +77,7 @@ function step_exchange_integrator(
     )
     freeze! = function (G, G_lim, u, p, t)
         freeze_count[] += 1
+        isnothing(log) || push!(log, (; hook = :freeze, t, u = copy(u)))
         mul!(G, A_full_exp, u)
         mul!(scratch, A_exp, u)
         G .-= scratch
@@ -111,7 +119,8 @@ end
         n_steps = [8, 16, 32, 64]
         t_end = 1.0
         dts = t_end ./ n_steps
-        for (outer, expected) in ((LieSplitOuter(), 1),)
+        for (outer, expected) in
+            ((LieSplitOuter(), 1), (TrapezoidalSplitOuter(), 2))
             errs = map(zip(dts, n_steps)) do (dt, ns)
                 res = run_step_exchange(
                     outer;
@@ -128,7 +137,8 @@ end
 
     @testset "slow-function call count" begin
         n_steps = 5
-        for (outer, per_step) in ((LieSplitOuter(), 1),)
+        for (outer, per_step) in
+            ((LieSplitOuter(), 1), (TrapezoidalSplitOuter(), 2))
             res = run_step_exchange(
                 outer;
                 dt = 0.1,
@@ -149,8 +159,40 @@ end
         @test norm(limited.u .- exact_solution(args.dt * args.n_steps)) < 5.0e-3
     end
 
+    @testset "trapezoidal second-pass cache refresh" begin
+        dt = 0.1
+        log = []
+        (; integ) = step_exchange_integrator(
+            TrapezoidalSplitOuter();
+            log,
+            dt,
+            fast_dt = dt / 4,
+            n_steps = 1,
+        )
+        CTS.step!(integ)
+        freezes = findall(e -> e.hook == :freeze, log)
+        @test length(freezes) == 2
+        @test log[freezes[1]].t == 0.0
+        @test log[freezes[1]].u == Y0
+        @test log[freezes[2]].t == dt
+        full = findall(e -> e.hook == :cache, log)
+        @test length(full) == 2
+        mid, final = full
+        # A full cache refresh occurs between the second-pass freeze and the
+        # second sub-cycle, paired with the second-pass restart state and time.
+        @test freezes[2] < mid
+        @test log[mid].t == 0.0
+        @test log[mid].u == Y0
+        restart = findnext(e -> e.hook == :cache_imp, log, mid + 1)
+        @test restart !== nothing && restart < final
+        @test log[restart].t == 0.0
+        @test log[restart].u == log[mid].u
+        @test log[final].t == dt
+        @test log[final].u == integ.u
+    end
+
     @testset "T_post_imp! threading" begin
-        for outer in (LieSplitOuter(),)
+        for outer in (LieSplitOuter(), TrapezoidalSplitOuter())
             post_count = Ref(0)
             post_imp! = function (du, u, p, t)
                 post_count[] += 1
@@ -167,7 +209,7 @@ end
     end
 
     @testset "constrain_state! threading" begin
-        for outer in (LieSplitOuter(),)
+        for outer in (LieSplitOuter(), TrapezoidalSplitOuter())
             constrain_count = Ref(0)
             constrain! = function (u, p, t)
                 constrain_count[] += 1
@@ -182,7 +224,7 @@ end
                 fast_dt = 0.1 / 4,
                 n_steps,
             )
-            # Applied once per outer step, to the end-of-step state.
+            # Applied once per outer step, to the combined end-of-step state.
             @test constrain_count[] == n_steps
             @test res.u[2] == 0.0
         end


### PR DESCRIPTION
Second in the step-exchange stack, on top of #442. Adds the two remaining members of the family: the second-order trapezoidal outer method and the optional outer implicit complement.

## Trapezoidal outer

`TrapezoidalSplitOuter` freezes the slow forcing at the step start, sub-cycles the fast system to a predicted end state, re-evaluates the slow forcing there, averages the two, and sub-cycles again from the step start with the averaged forcing:

```math
U_0 = u^n, \qquad G_1 = f_\text{slow}(U_0), \qquad G_2 = f_\text{slow}\Big(\Phi^{\Delta t}\big[f_\text{fast} + G_1\big](U_0)\Big),
```

```math
u^{n+1} = \Phi^{\Delta t}\big[f_\text{fast} + \tfrac{1}{2}(G_1 + G_2)\big](U_0),
```

with $\Phi^{\Delta t}$ the inner sub-cycle. This is a predictor-corrector composition, not an average of two end states. The second sub-cycle restarts from the step-start state after a full `cache!` refresh at that state, so the predicted-state forcing evaluation does not leave the cache paired with a state one step ahead.

## Outer implicit complement

Both outer methods take an optional `complement`, a callable `(u, p, t, dt) -> nothing` that advances `u` in place. It models an inner/outer implicit split: the inner sub-cycle solves a restricted implicit operator (for the acoustic application, the vertical-acoustic block) and the complement advances the remaining implicit terms once per outer step, rather than re-solving the full implicit operator every sub-step. `LieSplitOuter` applies it once over the step; `TrapezoidalSplitOuter` brackets the sub-cycle with two half-step calls (Strang splitting), refreshing the full cache at the sub-cycled end state before the second call. The application supplies the complement; the outer method only sequences it. `nothing` disables it, and the trapezoidal half-step `dt / 2` is then never computed.

This is the mechanism for the acoustic throughput optimization (restricting the sub-cycle implicit solve to the acoustic block); it has no in-tree consumer yet, so it ships as an inert option here rather than as a separate consumer-less change.

## Verification

`test/solvers/multirate_step_exchange.jl` gains the order-2 convergence check, the complement sequencing (once per step for Lie, two half-steps for trapezoidal), and log-based tests of the second-pass and pre-complement cache refreshes, alongside the order-1 checks from #442. The existing suite is unchanged.

Stacked on #442; review that first.
