### PR TITLE
Bugfix: explicit-only increment in SSPRK

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@ ClimaTimeSteppers.jl Release Notes
 main
 -------
 
+v0.10.6
+-------
+- ![][badge-🐛bugfix] Explicit-only problems stepped with an SSP `IMEXAlgorithm` no
+  longer broadcast the `0` implicit-increment sentinel into the stage state.
+  `update_stage!` evaluated `@. U = U_exp + inc_imp` unconditionally, so when
+  `inc_imp` was the `0` returned for a problem with no `T_imp!`, states whose
+  elements define no `+` against a scalar (e.g. a `ClimaCore` `Geometry` vector, or
+  a `StaticArrays` `SVector`) raised a `MethodError`. Now guarded by the same
+  `!== 0` check already used in `step_u!`.
+
 v0.10.5
 -------
 - ![][badge-🐛bugfix] `RosenbrockAlgorithm` now falls back to `cache_imp!` at intermediate

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaTimeSteppers"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/src/solvers/explicit_tableaus.jl
+++ b/src/solvers/explicit_tableaus.jl
@@ -90,9 +90,9 @@ Also called Heun's method ([Heun1900](@cite)).
 struct SSP22Heuns <: SSPRKAlgorithmName end
 function ExplicitTableau(::SSP22Heuns)
     return ExplicitTableau(; a = @SArray([
-            0 0
-            1 0
-        ]), b = @SArray([1 / 2, 1 / 2]))
+        0 0
+        1 0
+    ]), b = @SArray([1 / 2, 1 / 2]))
 end
 
 """

--- a/src/solvers/imex_ssprk.jl
+++ b/src/solvers/imex_ssprk.jl
@@ -164,7 +164,11 @@ end
     end
 
     inc_imp = !has_T_imp(f) ? 0 : fused_raw_increment(dt, a_imp, T_imp, v_i)
-    @. U = U_exp + inc_imp
+    if inc_imp !== 0
+        @. U = U_exp + inc_imp
+    else
+        @. U = U_exp
+    end
 
     # Apply DSS, set up and run the implicit solve (honoring `initialize_imp!`),
     # and update the cache/constraints. Shared with the IMEX-ARK path so the two

--- a/test/integration/callbacks.jl
+++ b/test/integration/callbacks.jl
@@ -53,16 +53,16 @@ cbs = CallbackSet(
     EveryXSimulationSteps(cb3, 1),
     EveryXSimulationSteps(cb4, 4, atinit = true),
     EveryXSimulationSteps(_ -> begin
-            # Simulate uneven computational load across MPI ranks to test 
-            # the distributed robustness of EveryXWallTimeSeconds. 
-            # The root rank checks wall time and broadcasts, ensuring all ranks 
-            # fire the callback at the same step despite different loads.
-            if ClimaComms.iamroot(comm_ctx)
-                sleep(1 / 32)
-            else
-                sleep(1 / 64)
-            end
-        end, 1),
+        # Simulate uneven computational load across MPI ranks to test 
+        # the distributed robustness of EveryXWallTimeSeconds. 
+        # The root rank checks wall time and broadcasts, ensuring all ranks 
+        # fire the callback at the same step despite different loads.
+        if ClimaComms.iamroot(comm_ctx)
+            sleep(1 / 32)
+        else
+            sleep(1 / 64)
+        end
+    end, 1),
     EveryXWallTimeSeconds(cb5, 0.49, comm_ctx),
 )
 

--- a/test/unit/edge_cases.jl
+++ b/test/unit/edge_cases.jl
@@ -1,7 +1,7 @@
 #=
 Edge case and error handling tests.
 =#
-using ClimaTimeSteppers, LinearAlgebra, Test
+using ClimaTimeSteppers, LinearAlgebra, StaticArrays, Test
 import ClimaTimeSteppers as CTS
 import ClimaTimeSteppers: ODEProblem, ODEFunction, solve
 
@@ -92,6 +92,24 @@ import ClimaTimeSteppers: ODEProblem, ODEFunction, solve
         sol = solve(prob, alg; dt = 0.01, save_everystep = false)
         @test sol.u[end][1] ≈ exp(-0.5) atol = 0.01
         @test sol.u[end][2] ≈ 2 * exp(-0.5) atol = 0.02
+    end
+
+    @testset "Explicit-only SSPRK with a state that rejects scalar addition" begin
+        # The `0` used in place of an implicit increment is a sentinel, not a
+        # value to broadcast: states whose elements are vectors (e.g. a
+        # ClimaCore `Geometry` vector) define no `+` against a scalar. Stepping
+        # an explicit-only problem must therefore never evaluate `U_exp + 0`.
+        @test_throws MethodError SVector(1.0, 2.0) + 0    # premise of this test
+
+        prob = ODEProblem(
+            ClimaODEFunction(; T_exp! = (du, u, p, t) -> (du .= .-u)),
+            [SVector(1.0, 2.0), SVector(3.0, 4.0)],
+            (0.0, 0.1),
+            nothing,
+        )
+        alg = ExplicitAlgorithm(SSP33ShuOsher())
+        sol = solve(prob, alg; dt = 0.01, save_everystep = false)
+        @test sol.u[end] ≈ [SVector(1.0, 2.0), SVector(3.0, 4.0)] .* exp(-0.1) rtol = 1e-4
     end
 
     @testset "Newton's method with zero initial residual" begin


### PR DESCRIPTION
`update_stage!` for `IMEXSSPRKCache` evaluated

    inc_imp = !has_T_imp(f) ? 0 : fused_raw_increment(dt, a_imp, T_imp, v_i)
    @. U = U_exp + inc_imp

unconditionally. The `0` is a sentinel meaning "no implicit increment", not a value to broadcast, and `step_u!` already guards it with `inc_imp_final !== 0` before adding. Without the same guard here, stepping a problem that has no `T_imp!` evaluated `U_exp + 0` against every element of the state, leading to errors.

That is a no-op for states of plain numbers, but states whose elements are vectors define no `+` against a scalar, so it raised

    MethodError: no method matching +(::UVVector{Float64}, ::Int64)

for ClimaCore states holding `Geometry` vectors, and likewise for `SVector` elements. Guard the add the same way `step_u!` does.

Adds a regression test using `SVector` elements, which reproduces the failure without pulling ClimaCore into the test environment, and bumps the patch version.